### PR TITLE
fix(transport): removes extraneous wrapping that breaks live request

### DIFF
--- a/src/router.test.ts
+++ b/src/router.test.ts
@@ -21,10 +21,10 @@ const makeMethodMapping = (methods: MethodObject[]): IMethodMapping => {
       );
       if (foundExample) {
         const foundExampleResult = foundExample.result as ExampleObject;
-        return Promise.resolve({ result: foundExampleResult.value });
+        return foundExampleResult.value;
       } else {
         const result = methodObject.result as ContentDescriptorObject;
-        return { result: await jsf.generate(result.schema) };
+        return jsf.generate(result.schema);
       }
     })
     .value();
@@ -52,7 +52,7 @@ describe("router", () => {
       if (exampleName === "simpleMath") {
         it("Simple math call works", async () => {
           const router = new Router(parsedExample, makeMethodMapping(parsedExample.methods));
-          const { result } = await router.call("addition", [2, 2]);
+          const result = await router.call("addition", [2, 2]);
           expect(result).toBe(4);
         });
 
@@ -69,13 +69,13 @@ describe("router", () => {
 
         it("works in mock mode with valid examplePairing params", async () => {
           const router = new Router(parsedExample, { mockMode: true });
-          const { result } = await router.call("addition", [2, 2]);
+          const result = await router.call("addition", [2, 2]);
           expect(result).toBe(4);
         });
 
         it("works in mock mode with unknown params", async () => {
           const router = new Router(parsedExample, { mockMode: true });
-          const { result } = await router.call("addition", [6, 2]);
+          const  result = await router.call("addition", [6, 2]);
           expect(typeof result).toBe("number");
         });
       }

--- a/src/router.ts
+++ b/src/router.ts
@@ -78,10 +78,10 @@ export class Router {
         );
         if (foundExample) {
           const foundExampleResult = foundExample.result as ExampleObject;
-          return Promise.resolve({ result: foundExampleResult.value });
+          return Promise.resolve(foundExampleResult.value);
         } else {
           const result = methodObject.result as ContentDescriptorObject;
-          return { result: await jsf.generate(result.schema) };
+          return jsf.generate(result.schema);
         }
       })
       .value();

--- a/src/transports/server-transport.ts
+++ b/src/transports/server-transport.ts
@@ -33,7 +33,7 @@ export default abstract class ServerTransport {
     return {
       id,
       jsonrpc: "2.0",
-      ...result,
+      result,
     };
   }
 }


### PR DESCRIPTION
This fixes an issue that occurs, because the api is expecting that results are passed back wrapped in an extra {result: } object. This expectation works in tests, but with live code. The actual values are not wrapped in an additional result. This causes the spread operator to then fail. 

I think the simplification of this is moving the actual formatting of the result to the transport-server layer. The fix is removing the spread operator and changing the examples to just return result, leaving the formatting of the return request to a single area. 

lmk what ya think. This fixes the server-js against live data.