### PR TITLE
feat: added --version flag for cli

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2297,8 +2297,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2319,14 +2318,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2341,20 +2338,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2471,8 +2465,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2484,7 +2477,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2499,7 +2491,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2507,14 +2498,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2533,7 +2522,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2614,8 +2602,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2627,7 +2614,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2713,8 +2699,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2750,7 +2735,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2770,7 +2754,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2814,14 +2797,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -5594,7 +5575,7 @@
         "string-to-stream": "^1.1.0",
         "typescript": "~2.8.3",
         "typescript-json-schema": "github:quicktype/typescript-json-schema#d16083d29c8b6702c666a981fa6b21113300c059",
-        "unicode-properties": "github:quicktype/unicode-properties#dist",
+        "unicode-properties": "github:quicktype/unicode-properties#d5fddfea1ef9d05c6479a979e225476063e13f52",
         "universal-analytics": "^0.4.16",
         "urijs": "^1.19.1",
         "uuid": "^3.2.1"
@@ -5622,7 +5603,7 @@
       "integrity": "sha512-aWoKL+mFAgV15KPf74Mdwx0Z6XKk8ZgWudRBXPSnXxdl7F453WDvjTmRxjAFVu0utDfr085oznXsg/cPuB9NVw==",
       "requires": {
         "@mark.probst/unicode-properties": "~1.1.0",
-        "@types/urijs": "github:quicktype/types-urijs",
+        "@types/urijs": "github:quicktype/types-urijs#a23603a04e31e883a92244bff8515e3d841a8b98",
         "collection-utils": "^1.0.1",
         "js-base64": "^2.4.3",
         "pako": "^1.0.6",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/open-rpc/server-js.git"
   },
-  "main": "./build/index.js",
+  "main": "./build/src/index.js",
   "bin": {
     "open-rpc-server-js": "./build/cli.js"
   },
@@ -16,7 +16,7 @@
     ".node-version"
   ],
   "scripts": {
-    "start": "./build/cli.js",
+    "start": "./build/src/cli.js",
     "test": "jest --coverage",
     "build": "tsc",
     "watch:build": "tsc --watch",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     ".node-version"
   ],
   "scripts": {
-    "start": "./build/src/cli.js",
+    "start": "./build/cli.js",
     "test": "jest --coverage",
     "build": "tsc",
     "watch:build": "tsc --watch",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/open-rpc/server-js.git"
   },
-  "main": "./build/src/index.js",
+  "main": "./build/index.js",
   "bin": {
     "open-rpc-server-js": "./build/cli.js"
   },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,8 +10,9 @@ import { keyBy, flatten, chain } from "lodash";
 import { IMethodMapping } from "./router";
 import { resolve } from "path";
 
-const readDir = util.promisify(fs.readdir);
+const version = require("../package.json").version; // tslint:disable-line
 
+const readDir = util.promisify(fs.readdir);
 const basePath = "./src/method-handlers";
 
 let methodMapping;
@@ -26,6 +27,7 @@ program
   .option("-d, --document <documentLocation>", "JSON string or a Path/Url pointing to an OpenROC document");
 
 program
+  .version(version, "-v, --version")
   .command("start")
   .action(async (env, options) => {
     console.log("Starting server with the following options:");


### PR DESCRIPTION
Changes:
- When requiring `package.json` in the `root/src/index.ts` file it messes with the build path.
- Instead of placing the build files in the `root/build/` folder it creates a `src` folder, changing the build path from `root/build/<PROJECT>` to `root/build/src/<PROJECT>`


Not sure why this is happening or if we want that, but I changed all paths to reflect this new build path.