### PR TITLE
feat: add support for custom errors

### DIFF
--- a/src/error.ts
+++ b/src/error.ts
@@ -1,0 +1,11 @@
+export class JSONRPCError extends Error {
+  public code: number;
+  public message: string;
+  public data?: any;
+  constructor(message: string, code: number, data?: any) {
+    super();
+    this.code = code;
+    this.message = message;
+    this.data = data;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,10 @@
 import Server, { IServerOptions } from "./server";
 import { Router } from "./router";
+import { JSONRPCError } from "./error";
 
 export {
   Server,
   IServerOptions,
   Router,
+  JSONRPCError,
 };

--- a/src/router.ts
+++ b/src/router.ts
@@ -7,7 +7,7 @@ import {
   OpenRPC,
 } from "@open-rpc/meta-schema";
 import { MethodCallValidator, MethodNotFoundError, ParameterValidationError } from "@open-rpc/schema-utils-js";
-import {JSONRPCError} from "./error";
+import { JSONRPCError } from "./error";
 
 const jsf = require("json-schema-faker"); // tslint:disable-line
 

--- a/src/router.ts
+++ b/src/router.ts
@@ -7,6 +7,8 @@ import {
   OpenRPC,
 } from "@open-rpc/meta-schema";
 import { MethodCallValidator, MethodNotFoundError, ParameterValidationError } from "@open-rpc/schema-utils-js";
+import {JSONRPCError} from "./error";
+
 const jsf = require("json-schema-faker"); // tslint:disable-line
 
 export interface IMethodMapping {
@@ -61,7 +63,10 @@ export class Router {
     try {
       return await this.methods[methodName](...params);
     } catch (e) {
-      return { code: 6969, message: "unknown error" };
+      if (e instanceof JSONRPCError) {
+        return {error: { code: e.code, message: e.message, data: e.data }};
+      }
+      return { error: { code: 6969, message: "unknown error" } };
     }
   }
 


### PR DESCRIPTION
This adds support for custom errors to
allow server implementers to relay unique codes and error messages
specific to their applications.

Throwing JSONRPCError now allows server method implementers to
specify code, error message, and metadata to respond with upon
error.

fixes #92