### PR TITLE
fix: params by name sortParamKeys should return val not return ["key",  val]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -881,9 +881,9 @@
       "integrity": "sha512-ch/pPoOEIeKe1PKbfuLEIM8MAdTiR+fr9BYk6VTlIHrya5f5d8shJg6h/oQgD3K/ftjU/RYBGGalw9Pz4pCXew=="
     },
     "@open-rpc/examples": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@open-rpc/examples/-/examples-1.6.0.tgz",
-      "integrity": "sha512-Fq704vsc0w7z8PI8VEJas6DmIhEqnUnP5TBwBMG6CPgPvqXIobqW51qeP+P6PUkJQyP9u9JlZJsLFqZojKl9cQ==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@open-rpc/examples/-/examples-1.6.1.tgz",
+      "integrity": "sha512-R0R8IimU5yJeAFe94GspnynIj0bv2AM57Px3cTwZkVwg6fCYOw+9l4gOQc402f+kSvZC7/BjNPyGtQ83oDbDYw==",
       "dev": true
     },
     "@open-rpc/meta-schema": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "ws": "^7.3.1"
   },
   "devDependencies": {
-    "@open-rpc/examples": "^1.6.0",
+    "@open-rpc/examples": "^1.6.1",
     "@open-rpc/meta-schema": "^1.13.20",
     "@types/body-parser": "^1.19.0",
     "@types/connect": "^3.4.33",

--- a/src/router.test.ts
+++ b/src/router.test.ts
@@ -111,6 +111,12 @@ describe("router", () => {
           expect(result).toEqual(parsedExample);
         });
 
+        it("can call rpc.discover with empty object", async () => {
+          const router = new Router(parsedExample, makeMethodMapping(parsedExample.methods));
+          const { result } = await router.call("rpc.discover", {});
+          expect(result).toEqual(parsedExample);
+        });
+
         it("Simple math call validates params", async () => {
           const router = new Router(parsedExample, makeMethodMapping(parsedExample.methods));
           const { error } = await router.call("addition", ["2", 2]);

--- a/src/router.test.ts
+++ b/src/router.test.ts
@@ -63,9 +63,12 @@ describe("router", () => {
       if (exampleName === "petstoreByName") {
         it("handles params by name", async () => {
           const router = new Router(parsedExample, makeMethodMapping(parsedExample.methods));
-          const result = await router.call("list_pets", { limit: 10 });
+          const result = await router.call("list_pets", { limit: 1 });
           expect(result).toBeDefined();
           expect(result.result.length).toBeGreaterThan(0);
+          expect(result.result[0].name).toBe("fluffy");
+          expect(result.result[0].id).toBe(7);
+          expect(result.result[0].tag).toBe("poodle");
         });
       }
       if (exampleName === "simpleMath") {

--- a/src/router.ts
+++ b/src/router.ts
@@ -20,7 +20,13 @@ export interface MockModeSettings {
 
 export type TMethodHandler = (...args: any) => Promise<any>;
 
-const sortParamKeys = (method: MethodObject, params: Record<string, unknown>) => {
+const sortParamKeys = (method?: MethodObject, params?: Record<string, unknown>) => {
+  if (!method) {
+    return [];
+  }
+  if (!params) {
+    return [];
+  }
   const docParams = method.params as ContentDescriptorObject[];
   const methodParamsOrder: { [k: string]: number } = docParams
     .map((p) => p.name)

--- a/src/router.ts
+++ b/src/router.ts
@@ -26,7 +26,9 @@ const sortParamKeys = (method: MethodObject, params: object) => {
     .map((p) => p.name)
     .reduce((m, pn, i) => ({ ...m, [pn]: i }), {});
 
-  return Object.entries(params).sort((v1, v2) => methodParamsOrder[v1[0]] - methodParamsOrder[v2[0]]);
+  return Object.entries(params)
+    .sort((v1, v2) => methodParamsOrder[v1[0]] - methodParamsOrder[v2[0]])
+    .map(([key, val]) => val);
 };
 
 export class Router {


### PR DESCRIPTION
fixes #391 
fixes https://github.com/open-rpc/mock-server/issues/379
fixes https://github.com/open-rpc/mock-server/issues/277