### PR TITLE
feat: this adds support for adding custom transports

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import Server, { ServerOptions } from "./server";
 import { Router } from "./router";
 import { JSONRPCError } from "./error";
+export * as transports from "./transports"
 
 export {
   Server,

--- a/src/transports/index.ts
+++ b/src/transports/index.ts
@@ -2,13 +2,15 @@ import WebSocketTransport, { WebSocketServerTransportOptions } from "./websocket
 import HTTPTransport, { HTTPServerTransportOptions } from "./http";
 import HTTPSTransport, { HTTPSServerTransportOptions } from "./https";
 import IPCTransport, { IPCServerTransportOptions } from "./ipc";
+import { ServerTransport } from "./server-transport";
+export {HTTPSTransport, HTTPTransport, WebSocketTransport, IPCTransport, ServerTransport}
 
 export type TransportNames = "IPCTransport" | "HTTPTransport" | "HTTPSTransport" | "WebSocketTransport";
 
 export type TransportClasses = WebSocketTransport |
   HTTPTransport |
   HTTPSTransport |
-  IPCTransport;
+  IPCTransport | ServerTransport;
 
 export type TransportOptions = WebSocketServerTransportOptions |
   HTTPServerTransportOptions |

--- a/src/transports/server-transport.test.ts
+++ b/src/transports/server-transport.test.ts
@@ -1,0 +1,13 @@
+import ServerTransport from "./server-transport";
+
+describe("Server transport test", () => {
+
+  class DummyTransport extends ServerTransport {
+
+  }
+
+  it("transport implementation throws without start", async () => {
+    expect(()=>new DummyTransport().start()).toThrowError()
+  });
+
+});

--- a/src/transports/server-transport.ts
+++ b/src/transports/server-transport.ts
@@ -20,7 +20,7 @@ export interface JSONRPCResponse {
   error?: JSONRPCErrorObject;
 }
 
-export default abstract class ServerTransport {
+export abstract class ServerTransport {
   public routers: Router[] = [];
 
   public addRouter(router: Router): void {
@@ -29,6 +29,11 @@ export default abstract class ServerTransport {
 
   public removeRouter(router: Router): void {
     this.routers = this.routers.filter((r) => r !== router);
+  }
+
+  public start(): void {
+    console.warn("Transport must implement start()"); // tslint:disable-line
+    throw new Error("Transport missing start implementation");
   }
 
   protected async routerHandler({ id, method, params }: JSONRPCRequest): Promise<JSONRPCResponse> {
@@ -60,3 +65,4 @@ export default abstract class ServerTransport {
     return res;
   }
 }
+export default ServerTransport;


### PR DESCRIPTION
this change breaks the existing addTransport interface and refactors
it to addDefaultTransport. This will allow users to add a transport,
where they have access to the underlying protocol features.

The motivation behind this is to make it easy for people to extend
the transport to fit their usage context. This will also be useful
for people that need access to what the transport is doing like
receiving context specific events.

In the case of notifications coming from the server, this will
allow the developer to eventually hook into an event stream
and add handlers to their transport of choice, something that might
be tricker to do under the abstraction layer provided.

This change is a stepping stone to that.

fixes #619