### PR TITLE
fix: use deep equal to compare deeply nested params

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "cors": "^2.8.5",
     "json-schema-faker": "^0.5.0-rcv.26",
     "node-ipc": "^9.1.1",
+    "lodash": "^4.17.19",
     "ws": "^8.0.0"
   },
   "devDependencies": {
@@ -51,7 +52,6 @@
     "@typescript-eslint/parser": "^4.9.1",
     "eslint": "^7.15.0",
     "jest": "^26.1.0",
-    "lodash": "^4.17.19",
     "node-fetch": "^2.6.0",
     "ts-jest": "^26.1.4",
     "typescript": "^4.0.2"

--- a/src/router.test.ts
+++ b/src/router.test.ts
@@ -133,6 +133,12 @@ describe("router", () => {
           expect(result).toBe(4);
         });
 
+        it("works in mock mode with valid examplePairing params", async () => {
+          const router = new Router(parsedExample, { mockMode: true });
+          const { result } = await router.call("addition", [2, 2]);
+          expect(result).toBe(4);
+        });
+
         it("works in mock mode with unknown params", async () => {
           const router = new Router(parsedExample, { mockMode: true });
           const { result } = await router.call("addition", [6, 2]);

--- a/src/router.test.ts
+++ b/src/router.test.ts
@@ -133,9 +133,9 @@ describe("router", () => {
           expect(result).toBe(4);
         });
 
-        it("works in mock mode with valid examplePairing params", async () => {
+        it("works in mock mode with valid examplePairing params with by-name", async () => {
           const router = new Router(parsedExample, { mockMode: true });
-          const { result } = await router.call("addition", [2, 2]);
+          const { result } = await router.call("addition", {a: 2, b: 2});
           expect(result).toBe(4);
         });
 

--- a/src/router.ts
+++ b/src/router.ts
@@ -6,6 +6,7 @@ import {
   OpenrpcDocument,
 } from "@open-rpc/meta-schema";
 import { MethodCallValidator, MethodNotFoundError, ParameterValidationError } from "@open-rpc/schema-utils-js";
+import _ from "lodash";
 import { JSONRPCError } from "./error";
 
 const jsf = require("json-schema-faker"); // eslint-disable-line
@@ -111,7 +112,8 @@ export class Router {
         const foundExample = (method.examples as ExamplePairingObject[]).find(({ params }) => {
           let isMatch = true;
           (params as ExampleObject[]).forEach((p, i) => {
-            if (p.value !== args[i]) { isMatch = false; }
+            const eq = _.isEqual(p.value, args[i]);
+            if (!eq) { isMatch = false; }
           });
           return isMatch;
         });


### PR DESCRIPTION
using built in js comparison wont work here for deeply nested params like objects.

related to this issue: https://github.com/open-rpc/mock-server/issues/511