### PR TITLE
Allow passing existing connect app

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,10 +153,14 @@ const UdpIpcTransport = new IPCServerTranport(UDPIPCTransportOptions);
 
 ```
 import { HTTPServerTransport, HTTPSServerTransport } from "@open-rpc/server-js";
+import express from "express";
+
+const existingApp = express();
 
 const httpOptions = {
   middleware: [ cors({ origin: "*" }) ],
-  port: 4345
+  port: 4345,
+  app: existingApp, // optional existing express/connect app
 };
 const httpsOptions = { // extends https://nodejs.org/api/https.html#https_https_createserver_options_requestlistener
   middleware: [ cors({ origin: "*" }) ],

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "build": "tsc",
     "watch:build": "tsc --watch",
     "watch:test": "jest --watch",
-    "lint": "eslint . --ext .ts"
+    "lint": "eslint . --ext .ts",
+    "lint:fix": "eslint . --ext .ts --fix"
   },
   "author": "",
   "license": "Apache-2.0",

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -1,0 +1,189 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+import Server from './server';
+import { ServerTransport } from './transports/server-transport';
+import { Router } from './router';
+
+// Create test classes we'll use directly
+class TestRouter implements Partial<Router> {
+  public isMethodImplemented = jest.fn();
+  public call = jest.fn();
+}
+
+class TestTransport extends ServerTransport {
+  public options: any;
+  
+  constructor(options: any = {}) {
+    super();
+    this.options = options;
+  }
+  
+  public start = jest.fn().mockResolvedValue(undefined);
+  public stop = jest.fn().mockResolvedValue(undefined);
+}
+
+// Create factory functions to use in tests
+const createTestRouter = () => new TestRouter() as unknown as Router;
+const createTestTransport = (options: any = {}) => new TestTransport(options);
+
+// Mock MethodCallValidator
+jest.mock('@open-rpc/schema-utils-js', () => ({
+  MethodCallValidator: jest.fn().mockImplementation(() => ({
+    validate: jest.fn(),
+  })),
+}));
+
+describe('Server', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'log').mockImplementation(() => { /* no-op */ });
+  });
+
+  it('initializes without routers or transports when no options provided', () => {
+    const server = new Server({ openrpcDocument: {} as any });
+    expect((server as any).routers).toHaveLength(0);
+    expect((server as any).transports).toHaveLength(0);
+  });
+
+  it('adds router when constructed with methodMapping', () => {
+    // Mock Router constructor
+    const originalRouter = require('./router').Router;
+    const mockRouter = createTestRouter();
+    require('./router').Router = jest.fn().mockReturnValue(mockRouter);
+    
+    const mapping = {} as any;
+    const server = new Server({ openrpcDocument: {} as any, methodMapping: mapping });
+    
+    // Verify Router was created with expected args
+    expect(require('./router').Router).toHaveBeenCalledWith({} as any, mapping);
+    expect((server as any).routers).toHaveLength(1);
+    
+    // Restore original Router
+    require('./router').Router = originalRouter;
+  });
+
+  it('adds default transport when constructed with transportConfigs', () => {
+    // Mock the transport factory
+    const originalTransports = require('./transports').default;
+    const mockTransport = createTestTransport({ port: 123 });
+    require('./transports').default = { 
+      HTTPTransport: jest.fn().mockReturnValue(mockTransport)
+    };
+    
+    // Mock the Router class to prevent it from trying to use actual MethodCallValidator
+    const originalRouter = require('./router').Router;
+    require('./router').Router = jest.fn().mockReturnValue(createTestRouter());
+    
+    const opts = { port: 123 } as any;
+    const server = new Server({
+      openrpcDocument: {} as any,
+      methodMapping: {} as any,
+      transportConfigs: [{ type: 'HTTPTransport', options: opts }],
+    });
+    
+    expect(console.log).toHaveBeenCalledWith(
+      `Adding Transport of the type HTTPTransport on port ${opts.port}`,
+    );
+    
+    expect((server as any).transports).toHaveLength(1);
+    expect((server as any).transports[0]).toBe(mockTransport);
+    expect(mockTransport.options).toEqual(opts);
+    
+    // Restore original modules
+    require('./transports').default = originalTransports;
+    require('./router').Router = originalRouter;
+  });
+
+  it('throws error on invalid transport type in addDefaultTransport', () => {
+    const server = new Server({ openrpcDocument: {} as any });
+    expect(() => {
+      (server as any).addDefaultTransport('InvalidTransport' as any, {} as any);
+    }).toThrow(
+      'The transport "InvalidTransport" is not a valid transport type.',
+    );
+  });
+
+  it('registers transport and attaches existing routers in addTransport', () => {
+    const server = new Server({ openrpcDocument: {} as any });
+    
+    // Create test data
+    const router1 = createTestRouter();
+    const router2 = createTestRouter();
+    (server as any).routers = [router1, router2];
+    
+    const transport = createTestTransport();
+    jest.spyOn(transport, 'addRouter');
+    
+    server.addTransport(transport);
+    
+    expect(transport.addRouter).toHaveBeenCalledTimes(2);
+    expect(transport.addRouter).toHaveBeenCalledWith(router1);
+    expect(transport.addRouter).toHaveBeenCalledWith(router2);
+    expect((server as any).transports).toContain(transport);
+  });
+
+  it('registers router and attaches to existing transports in addRouter', () => {
+    // Mock Router constructor
+    const originalRouter = require('./router').Router;
+    const mockRouter = createTestRouter();
+    require('./router').Router = jest.fn().mockReturnValue(mockRouter);
+    
+    const server = new Server({ openrpcDocument: {} as any });
+    
+    // Create test data
+    const transport = createTestTransport();
+    jest.spyOn(transport, 'addRouter');
+    (server as any).transports = [transport];
+    
+    const router = server.addRouter({} as any, {} as any);
+    
+    expect(require('./router').Router).toHaveBeenCalledWith({}, {} as any);
+    expect(transport.addRouter).toHaveBeenCalledWith(router);
+    expect((server as any).routers).toContain(router);
+    
+    // Restore original Router
+    require('./router').Router = originalRouter;
+  });
+
+  it('deregisters router and detaches from transports in removeRouter', () => {
+    const server = new Server({ openrpcDocument: {} as any });
+    
+    // Create test data
+    const router = createTestRouter();
+    const transport = createTestTransport();
+    jest.spyOn(transport, 'removeRouter');
+    
+    (server as any).transports = [transport];
+    (server as any).routers = [router];
+    
+    server.removeRouter(router);
+    
+    expect((server as any).routers).not.toContain(router);
+    expect(transport.removeRouter).toHaveBeenCalledWith(router);
+  });
+
+  it('calls start on transports in start', async () => {
+    const server = new Server({ openrpcDocument: {} as any });
+    
+    // Create test data
+    const transport = createTestTransport();
+    
+    (server as any).transports = [transport];
+    
+    await server.start();
+    
+    expect(transport.start).toHaveBeenCalled();
+  });
+
+  it('calls stop on transports in stop', async () => {
+    const server = new Server({ openrpcDocument: {} as any });
+    
+    // Create test data
+    const transport = createTestTransport();
+    
+    (server as any).transports = [transport];
+    
+    await server.stop();
+    
+    expect(transport.stop).toHaveBeenCalled();
+  });
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -71,8 +71,16 @@ export default class Server {
     this.transports.forEach((transport) => transport.removeRouter(routerToRemove));
   }
 
-  public start() {
-    this.transports.forEach((transport) => transport.start());
+  public async start() {
+    for (const transport of this.transports) {
+      await transport.start();
+    }
+  }
+
+  public async stop() {
+    for (const transport of this.transports) {
+      await transport.stop();
+    }
   }
 
 }

--- a/src/transports/https.test.ts
+++ b/src/transports/https.test.ts
@@ -5,12 +5,12 @@ import * as fs from "fs";
 import { promisify } from "util";
 import HTTPSTransport from "./https";
 const readFile = promisify(fs.readFile);
-import https from "https";
 import cors from "cors";
 import { json as jsonParser } from "body-parser";
 import { HandleFunction } from "connect";
 import { JSONRPCResponse } from "./server-transport";
 import { Agent } from 'undici';
+import connect from "connect";
 
 const agent = new Agent({
   connect: {
@@ -38,11 +38,11 @@ describe("https transport", () => {
 
     transport.addRouter(router);
 
-    transport.start();
+    await transport.start();
   });
 
-  afterAll(() => {
-    transport.stop();
+  afterAll(async () => {
+    await transport.stop();
   });
 
   it("can start an https server that works", async () => {
@@ -83,5 +83,90 @@ describe("https transport", () => {
 
     const pluckedResult = result.map((r: JSONRPCResponse) => r.result);
     expect(pluckedResult).toEqual([4, 8]);
+  });
+
+  it("allows using an existing app (HTTPS)", async () => {
+    const app = connect();
+    const simpleMathExample = await parseOpenRPCDocument(examples.simpleMath);
+    const transport = new HTTPSTransport({
+      cert: await readFile(`${process.cwd()}/test-cert/server.cert`),
+      key: await readFile(`${process.cwd()}/test-cert/server.key`),
+      middleware: [],
+      port: 9701,
+      app,
+    });
+    const router = new Router(simpleMathExample, { mockMode: true });
+    transport.addRouter(router);
+    try {
+      await transport.start();
+      const { result } = await fetch("https://localhost:9701", {
+        dispatcher: agent,
+        body: JSON.stringify({
+          id: "2",
+          jsonrpc: "2.0",
+          method: "addition",
+          params: [2, 2],
+        }),
+        headers: { "Content-Type": "application/json" },
+        method: "post",
+      }).then((res) => res.json() as Promise<JSONRPCResponse>);
+      expect(result).toBe(4);
+    } finally {
+      await transport.stop();
+    }
+  }, 30000);
+
+  it("handles errors when starting the server (HTTPS)", async () => {
+    const transport = new HTTPSTransport({
+      cert: await readFile(`${process.cwd()}/test-cert/server.cert`),
+      key: await readFile(`${process.cwd()}/test-cert/server.key`),
+      middleware: [],
+      port: 9708,
+    });
+    const serverInstance = (transport as any).server;
+    const originalListen = serverInstance.listen.bind(serverInstance);
+    serverInstance.listen = (port: number, cb: (err?: Error) => void) => {
+      cb(new Error("Mock listen error"));
+      return serverInstance;
+    };
+    await expect(transport.start()).rejects.toThrow("Mock listen error");
+    serverInstance.listen = originalListen;
+    // Do not call stop, since server never started
+  });
+
+  it("handles errors when stopping the server (HTTPS)", async () => {
+    const transport = new HTTPSTransport({
+      cert: await readFile(`${process.cwd()}/test-cert/server.cert`),
+      key: await readFile(`${process.cwd()}/test-cert/server.key`),
+      middleware: [],
+      port: 9709, // Using a new port to avoid conflicts
+    });
+    await transport.start(); // Start the server first
+
+    const serverInstance = (transport as any).server;
+    const originalClose = serverInstance.close.bind(serverInstance);
+    serverInstance.close = (cb: (err?: Error) => void) => {
+      cb(new Error("Mock close error"));
+      // REAL http2.Http2SecureServer.close() returns the server instance.
+      // we need to return something that has a .close method for the promisify to work.
+      // but it doesnt matter since we are testing the error case.
+      return serverInstance;
+    };
+    await expect(transport.stop()).rejects.toThrow("Mock close error");
+    serverInstance.close = originalClose; // Restore original close
+    // Attempt to gracefully close the server if the mock wasn't called or test failed before mock.
+    // This might not be strictly necessary if the test passes and mock is restored.
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const s = (transport as any).server as any;
+        if (s && s.listening) {
+          s.close((err?: Error) => err ? reject(err) : resolve());
+        } else {
+          resolve();
+        }
+      });
+    } catch (e) {
+      // ignore errors during cleanup
+    }
   });
 });

--- a/src/transports/ipc.test.ts
+++ b/src/transports/ipc.test.ts
@@ -18,7 +18,7 @@ describe("IPC transport", () => {
     });
     const router = new Router(simpleMathExample, { mockMode: true });
     transport.addRouter(router);
-    transport.start();
+    await transport.start();
     ipc.config.id = "simpleMath";
     ipc.config.retry = 1500;
     return new Promise((resolve, reject) => {
@@ -32,9 +32,9 @@ describe("IPC transport", () => {
     });
   });
 
-  afterAll(() => {
+  afterAll(async () => {
     ipc.disconnect("simpleMath");
-    transport.stop();
+    await transport.stop();
   });
 
   it("can start an IPC server that works", (done) => {
@@ -56,13 +56,13 @@ describe("IPC transport", () => {
         params: [2, 2],
       }),
     );
-  });
+  }, 60000);
 
   it("works with batching", (done) => {
     const handle = (data: any) => {
       ipc.of.simpleMath.off("message", handle);
-      const result = JSON.parse(data) as JSONRPCResponse[];
-      expect(result.map((r) => r.result)).toEqual([4, 8]);
+      const responses = JSON.parse(data) as JSONRPCResponse[];
+      expect(responses.map((r) => r.result)).toEqual([4, 8]);
       done();
     };
 
@@ -84,5 +84,5 @@ describe("IPC transport", () => {
         },
       ]),
     );
-  });
+  }, 60000);
 });

--- a/src/transports/ipc.ts
+++ b/src/transports/ipc.ts
@@ -44,12 +44,16 @@ export default class IPCServerTransport extends ServerTransport {
     this.server = ipc.server;
   }
 
-  public start() {
+  public async start(): Promise<void> {
     this.server.start(this.options.port);
+    // node-ipc is sync, but yield to event loop to ensure server is ready
+    await new Promise((resolve) => setImmediate(resolve));
   }
 
-  public stop() {
+  public async stop(): Promise<void> {
     this.server.stop();
+    // node-ipc is sync, but yield to event loop to ensure server is stopped
+    await new Promise((resolve) => setImmediate(resolve));
   }
 
   private async ipcRouterHandler(req: any, respondWith: any) {

--- a/src/transports/server-transport.test.ts
+++ b/src/transports/server-transport.test.ts
@@ -7,7 +7,48 @@ describe("Server transport test", () => {
   }
 
   it("transport implementation throws without start", async () => {
-    expect(()=>new DummyTransport().start()).toThrowError()
+    await expect(async () => { await new DummyTransport().start(); }).rejects.toThrowError();
+  });
+
+  it("throws if no router is configured", async () => {
+    const t = new DummyTransport();
+    await expect(t['routerHandler']({ jsonrpc: "2.0", id: "1", method: "foo", params: [] }))
+      .rejects.toThrow("No router configured");
+  });
+
+  it("returns method not found if method is not implemented", async () => {
+    const t = new DummyTransport();
+    // Mock a router that doesn't implement any method
+    const fakeRouter = { isMethodImplemented: () => false, call: jest.fn() } as unknown as import("../router").Router;
+    t.addRouter(fakeRouter);
+    const result = await t['routerHandler']({ jsonrpc: "2.0", id: "1", method: "foo", params: [] });
+    expect(result.error).toBeDefined();
+    expect(result.error?.code).toBe(-32601); // Method not found
+  });
+
+  it("returns result if method is implemented", async () => {
+    const t = new DummyTransport();
+    const fakeRouter = {
+      isMethodImplemented: () => true,
+      call: async () => ({ result: 42 }),
+    } as unknown as import("../router").Router;
+    t.addRouter(fakeRouter);
+    const result = await t['routerHandler']({ jsonrpc: "2.0", id: "1", method: "bar", params: [] });
+    expect(result.result).toBe(42);
+  });
+
+  it("covers the no router configured branch in routerHandler", async () => {
+    class DummyTransport extends ServerTransport {}
+    const t = new DummyTransport();
+    await expect(
+      t['routerHandler']({ jsonrpc: "2.0", id: "no-router", method: "foo", params: [] })
+    ).rejects.toThrow("No router configured");
+  });
+
+  it("throws if stop is not implemented", async () => {
+    class DummyTransport extends ServerTransport {}
+    const t = new DummyTransport();
+    await expect(t.stop()).rejects.toThrow("Transport missing stop implementation");
   });
 
 });

--- a/src/transports/server-transport.ts
+++ b/src/transports/server-transport.ts
@@ -31,9 +31,14 @@ export abstract class ServerTransport {
     this.routers = this.routers.filter((r) => r !== router);
   }
 
-  public start(): void {
+  public async start(): Promise<void> {
     console.warn("Transport must implement start()"); // tslint:disable-line
     throw new Error("Transport missing start implementation");
+  }
+
+  public async stop(): Promise<void> {
+    console.warn("Transport must implement stop()"); // tslint:disable-line
+    throw new Error("Transport missing stop implementation");
   }
 
   protected async routerHandler({ id, method, params }: JSONRPCRequest): Promise<JSONRPCResponse> {

--- a/src/transports/websocket.test.ts
+++ b/src/transports/websocket.test.ts
@@ -345,4 +345,21 @@ describe("WebSocket transport", () => {
     expect(mockWss.close).toHaveBeenCalled();
     expect(mockServer.close).toHaveBeenCalled();
   });
+
+  it("applies default timeout when none provided", () => {
+    const transport = new WebSocketTransport({
+      middleware: [],
+      port: 9710,
+    });
+    expect((transport as any).options.timeout).toBe(3000);
+  });
+
+  it("respects provided timeout", () => {
+    const transport = new WebSocketTransport({
+      middleware: [],
+      port: 9711,
+      timeout: 5000,
+    });
+    expect((transport as any).options.timeout).toBe(5000);
+  });
 });

--- a/src/transports/websocket.ts
+++ b/src/transports/websocket.ts
@@ -12,6 +12,7 @@ export interface WebSocketServerTransportOptions extends SecureServerOptions {
   cors?: cors.CorsOptions;
   allowHTTP1?: boolean;
   app?: ConnectApp;
+  timeout?: number = 3000;
 }
 
 export default class WebSocketServerTransport extends ServerTransport {

--- a/src/transports/websocket.ts
+++ b/src/transports/websocket.ts
@@ -72,7 +72,7 @@ export default class WebSocketServerTransport extends ServerTransport {
       socket.close();
     });
     // Wait for sockets to close, then hard close any remaining
-    await new Promise((resolve) => setTimeout(resolve, 3000));
+    await new Promise((resolve) => setTimeout(resolve, this.options.timeout));
     this.wss.clients.forEach((socket) => {
       if ([socket.OPEN, socket.CLOSING].includes((socket as any).readyState)) {
         socket.terminate();

--- a/src/transports/websocket.ts
+++ b/src/transports/websocket.ts
@@ -12,7 +12,7 @@ export interface WebSocketServerTransportOptions extends SecureServerOptions {
   cors?: cors.CorsOptions;
   allowHTTP1?: boolean;
   app?: ConnectApp;
-  timeout?: number = 3000;
+  timeout?: number;
 }
 
 export default class WebSocketServerTransport extends ServerTransport {
@@ -22,6 +22,8 @@ export default class WebSocketServerTransport extends ServerTransport {
 
   constructor(private options: WebSocketServerTransportOptions) {
     super();
+    // Ensure a default timeout if none provided
+    options.timeout = options.timeout ?? 3000;
     options.allowHTTP1 = true;
 
     const app = options.app || connect();


### PR DESCRIPTION
## Summary
- allow HTTP and HTTPS transports to accept a preexisting connect/express app
- document `app` option in README
- test using an external app
- adds `server.stop()`
- ensure `stop` and `start` are async

## Testing
- `npm test`


fixes #774
fixes #759

- -> #862
- #863