### PR TITLE
Validate method existence and standardize error handling

### DIFF
--- a/src/router.test.ts
+++ b/src/router.test.ts
@@ -84,6 +84,14 @@ describe("router", () => {
           expect((error as JSONRPCErrorObject).code).toBe(-32601);
         });
 
+        it("returns not found error when method is not implemented", async () => {
+          const methodMapping = makeMethodMapping(parsedExample.methods as MethodObject[]);
+          delete methodMapping["addition"];
+          const router = new Router(parsedExample, methodMapping);
+          const { error } = await router.call("addition", [2, 2]);
+          expect((error as JSONRPCErrorObject).code).toBe(-32601);
+        });
+
         it("returns param validation error when passing incorrect params", async () => {
           const router = new Router(parsedExample, makeMethodMapping(parsedExample.methods as MethodObject[]));
           const { error } = await router.call("addition", ["123", "321"]);
@@ -101,8 +109,9 @@ describe("router", () => {
         it("returns Unknown Error data when thrown", async () => {
           const router = new Router(parsedExample, makeMethodMapping(parsedExample.methods as MethodObject[]));
           const { error } = await router.call("unknown-error", []);
-          expect((error as JSONRPCErrorObject).code).toBe(6969);
-          expect((error as JSONRPCErrorObject).message).toBe("unknown error");
+          expect((error as JSONRPCErrorObject).code).toBe(-32603);
+          expect((error as JSONRPCErrorObject).message).toBe("Internal error");
+          expect((error as JSONRPCErrorObject).data).toBe("unanticpated crash");
         });
 
         it("implements service discovery", async () => {

--- a/src/router.ts
+++ b/src/router.ts
@@ -79,6 +79,10 @@ export class Router {
       return this.invalidParamsHandler(validationErrors);
     }
 
+    if (!this.isMethodImplemented(methodName)) {
+      return Router.methodNotFoundHandler(methodName);
+    }
+
     const methodObject = (this.openrpcDocument.methods as MethodObject[]).find((m) => m.name === methodName) as MethodObject;
 
     const paramsAsArray = params instanceof Array ? params : toArray(methodObject, params);
@@ -89,7 +93,8 @@ export class Router {
       if (e instanceof JSONRPCError) {
         return { error: { code: e.code, message: e.message, data: e.data } };
       }
-      return { error: { code: 6969, message: "unknown error" } };
+      const message = e instanceof Error ? e.message : String(e);
+      return { error: { code: -32603, message: "Internal error", data: message } };
     }
   }
 


### PR DESCRIPTION
## Summary
- ensure router verifies method implementations before invocation
- replace non-standard error code with JSON-RPC internal error
- add tests for unimplemented and internal error cases

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b33c4ff1c4832f9345bdb4a36860cf