### PR TITLE
fix: ignore JSON-RPC notifications

### DIFF
--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -61,12 +61,28 @@ export default class HTTPServerTransport extends ServerTransport {
   }
 
   private async httpRouterHandler(req: any, res: any): Promise<void> {
-    let result = null;
     if (req.body instanceof Array) {
-      result = await Promise.all(req.body.map((r: JSONRPCRequest) => super.routerHandler(r)));
-    } else {
-      result = await super.routerHandler(req.body);
+      const result = (await Promise.all(req.body.map((r: JSONRPCRequest) => super.routerHandler(r))))
+        .filter((r) => r !== undefined);
+
+      if (result.length === 0) {
+        res.statusCode = 204;
+        res.end();
+        return;
+      }
+
+      res.setHeader("Content-Type", "application/json");
+      res.end(JSON.stringify(result));
+      return;
     }
+
+    const result = await super.routerHandler(req.body);
+    if (result === undefined) {
+      res.statusCode = 204;
+      res.end();
+      return;
+    }
+
     res.setHeader("Content-Type", "application/json");
     res.end(JSON.stringify(result));
   }

--- a/src/transports/ipc.ts
+++ b/src/transports/ipc.ts
@@ -57,12 +57,23 @@ export default class IPCServerTransport extends ServerTransport {
   }
 
   private async ipcRouterHandler(req: any, respondWith: any) {
-    let result = null;
     if (req instanceof Array) {
-      result = await Promise.all(req.map((jsonrpcReq: JSONRPCRequest) => super.routerHandler(jsonrpcReq)));
-    } else {
-      result = await super.routerHandler(req);
+      const result = (await Promise.all(req.map((jsonrpcReq: JSONRPCRequest) => super.routerHandler(jsonrpcReq))))
+        .filter((r) => r !== undefined);
+
+      if (result.length === 0) {
+        return;
+      }
+
+      respondWith(JSON.stringify(result));
+      return;
     }
+
+    const result = await super.routerHandler(req);
+    if (result === undefined) {
+      return;
+    }
+
     respondWith(JSON.stringify(result));
   }
 }

--- a/src/transports/websocket.ts
+++ b/src/transports/websocket.ts
@@ -91,12 +91,23 @@ export default class WebSocketServerTransport extends ServerTransport {
   }
 
   private async webSocketRouterHandler(req: any, respondWith: any) {
-    let result = null;
     if (req instanceof Array) {
-      result = await Promise.all(req.map((r: JSONRPCRequest) => super.routerHandler(r)));
-    } else {
-      result = await super.routerHandler(req);
+      const result = (await Promise.all(req.map((r: JSONRPCRequest) => super.routerHandler(r))))
+        .filter((r) => r !== undefined);
+
+      if (result.length === 0) {
+        return;
+      }
+
+      respondWith(JSON.stringify(result));
+      return;
     }
+
+    const result = await super.routerHandler(req);
+    if (result === undefined) {
+      return;
+    }
+
     respondWith(JSON.stringify(result));
   }
 }


### PR DESCRIPTION
## Summary
- stop router handler from replying to JSON-RPC notifications
- filter notifications from HTTP/HTTPS/WebSocket/IPC responses
- add tests for notification handling

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b362c26dc0832fad10379451e75d66