### PR TITLE
fix: handle invalid websocket JSON

### DIFF
--- a/src/transports/websocket.test.ts
+++ b/src/transports/websocket.test.ts
@@ -355,6 +355,35 @@ describe("WebSocket transport", () => {
     expect(mockServer.close).toHaveBeenCalled();
   });
 
+  it("returns a parse error for invalid JSON and stays alive", async () => {
+    const simpleMathExample = await parseOpenRPCDocument(examples.simpleMath);
+    const transport = new WebSocketTransport({
+      middleware: [],
+      port: 9712,
+    });
+    const router = new Router(simpleMathExample, { mockMode: true });
+    transport.addRouter(router);
+    await transport.start();
+
+    const ws = new WebSocket("ws://localhost:9712");
+
+    await new Promise<void>((resolve, reject) => {
+      ws.on("message", (raw: WebSocket.Data) => {
+        const payload = JSON.parse(raw.toString());
+        expect(payload.error).toEqual({ code: -32700, message: "Parse error" });
+        expect(payload.id).toBeNull();
+        resolve();
+      });
+      ws.on("error", reject);
+      ws.on("open", () => {
+        ws.send("this is not json");
+      });
+    });
+
+    ws.close();
+    await transport.stop();
+  });
+
   it("applies default timeout when none provided", () => {
     const transport = new WebSocketTransport({
       middleware: [],

--- a/src/transports/websocket.ts
+++ b/src/transports/websocket.ts
@@ -51,10 +51,21 @@ export default class WebSocketServerTransport extends ServerTransport {
     this.wss = new WebSocket.Server({ server: this.server as any });
 
     this.wss.on("connection", (ws: WebSocket) => {
-      ws.on(
-        "message",
-        (message: string) => this.webSocketRouterHandler(JSON.parse(message), ws.send.bind(ws)),
-      );
+      ws.on("message", (message: WebSocket.RawData) => {
+        try {
+          const parsed = JSON.parse(typeof message === "string" ? message : message.toString());
+          void this.webSocketRouterHandler(parsed, ws.send.bind(ws));
+        } catch (err) {
+          ws.send(JSON.stringify({
+            jsonrpc: "2.0",
+            id: null,
+            error: {
+              code: -32700,
+              message: "Parse error",
+            },
+          }));
+        }
+      });
       ws.on("close", () => ws.removeAllListeners());
     });
   }


### PR DESCRIPTION
## Summary\n- catch JSON.parse failures in the ws transport and reply with a JSON-RPC -32700 error\n- add regression test to ensure a bad frame doesn\'t crash the server\n\nFixes #748